### PR TITLE
Maven命令编译时，同时编译所有xml配置文件，避免生成war包缺失部分xml配置文件

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,18 @@
 				</configuration>
 			</plugin>
 		</plugins>
+<!-- 加载本地xml配置文件 -->
+    <resources>
+			<resource>
+				<directory>src/main/java</directory>
+					<includes>
+					<include>**/*.xml</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+    </resources>
   </build>
 </project>
  


### PR DESCRIPTION
Maven命令编译时，同时编译所有xml配置文件，避免生成war包缺失部分xml配置文件